### PR TITLE
Improve recommendation feedback handling

### DIFF
--- a/backend/app/services/openai_service.py
+++ b/backend/app/services/openai_service.py
@@ -420,6 +420,18 @@ Focus on actionable details that would help find similar clothing items."""
                     unique_colors = list(set([c for c in colors_in_recs if c]))
                     if unique_colors:
                         context_parts.append(f"Color palette in recommendations: {', '.join(unique_colors[:5])}")
+
+            # Add user interaction history for personalized advice
+            if "user_interactions" in context:
+                interactions = context["user_interactions"]
+                liked = interactions.get("liked", [])
+                disliked = interactions.get("disliked", [])
+                if liked or disliked:
+                    context_parts.append("User Feedback:")
+                if liked:
+                    context_parts.append(f"- Liked items: {', '.join(liked)}")
+                if disliked:
+                    context_parts.append(f"- Disliked items: {', '.join(disliked)}")
         
         # Add context information to messages if available
         if context_parts:

--- a/src/components/wizard/Step6OutfitRail.tsx
+++ b/src/components/wizard/Step6OutfitRail.tsx
@@ -290,9 +290,17 @@ export const Step6OutfitRail: React.FC = () => {
   }
 
   const toggleLike = (itemId: string) => {
-    setAllItems((prev: ClothingItem[]) => prev.map((item: ClothingItem) => 
+    setAllItems((prev: ClothingItem[]) => prev.map((item: ClothingItem) =>
       item.id === itemId ? { ...item, liked: !item.liked, disliked: false } : item
     ))
+
+    if (currentSessionId) {
+      apiService.sendFeedback({
+        product_id: itemId,
+        action: 'like',
+        session_id: currentSessionId,
+      }).catch(err => console.error('Feedback error:', err))
+    }
   }
 
   const toggleDislike = async (itemId: string) => {
@@ -301,6 +309,14 @@ export const Step6OutfitRail: React.FC = () => {
 
     if (!item.disliked) {
       console.log('👎 DISLIKE: User disliked item:', item.name)
+
+      if (currentSessionId) {
+        apiService.sendFeedback({
+          product_id: itemId,
+          action: 'dislike',
+          session_id: currentSessionId,
+        }).catch(err => console.error('Feedback error:', err))
+      }
       
       // Start the removal animation
       setRemovingItems((prev: Set<string>) => new Set([...prev, itemId]))

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -155,7 +155,10 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
       
       // Current recommendations
       current_recommendations: formData.selectedItems || [],
-      
+
+      // User interactions for likes/dislikes
+      user_interactions: formData.userInteractions || { liked: [], disliked: [], addedToCart: [] },
+
       // Session tracking
       session_id: sessionId || formData.sessionId || null
     }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -78,8 +78,8 @@ export interface TryonResponse {
 
 export interface FeedbackRequest {
   product_id: string
-  feedback_type: 'like' | 'dislike'
-  user_profile: UserProfile
+  action: 'like' | 'dislike' | 'save'
+  session_id?: string
   reason?: string
 }
 


### PR DESCRIPTION
## Summary
- record recommendations and interactions in session cache
- include user interactions in chat context and conversation
- update API types and call feedback endpoint from UI

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bb2bd7198832abb85a0b6a86fe2d7